### PR TITLE
Fix demo mode escape with no password

### DIFF
--- a/demo_app.py
+++ b/demo_app.py
@@ -304,7 +304,7 @@ class DemoModeApp:
         stored_password = self.settings_manager.get('master_password')
 
         # If no password is set, exit directly without prompting
-        if not stored_password:
+        if stored_password is None or stored_password == "":
             self.stop_demo_mode()
             return
 

--- a/demo_app.py
+++ b/demo_app.py
@@ -301,12 +301,21 @@ class DemoModeApp:
     
     def prompt_master_password(self):
         """Prompt for master password to exit demo mode"""
-        password_dialog = PasswordDialog(self.root, "Enter Master Password", 
-                                       "Enter the master password to exit demo mode:")
+        stored_password = self.settings_manager.get('master_password')
+
+        # If no password is set, exit directly without prompting
+        if not stored_password:
+            self.stop_demo_mode()
+            return
+
+        password_dialog = PasswordDialog(
+            self.root,
+            "Enter Master Password",
+            "Enter the master password to exit demo mode:"
+        )
         self.root.wait_window(password_dialog.dialog)
-        
+
         if password_dialog.result:
-            stored_password = self.settings_manager.get('master_password')
             if self.settings_manager.verify_password(password_dialog.result, stored_password):
                 self.stop_demo_mode()
             else:


### PR DESCRIPTION
## Summary
- allow exiting demo mode without password if none is set

## Testing
- `python test_demo_app.py` *(fails: No module named 'cryptography', 'winreg', 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_684980628dfc832294b9277e3a18eb24